### PR TITLE
Minor fixes + support for Manifest Backend

### DIFF
--- a/minichain/base.py
+++ b/minichain/base.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Generic, List, Optional, Sequence, TypeVar
+from typing import Generic, List, Optional, Sequence, TypeVar, Union
 
 import trio
 from eliot import start_action
@@ -55,7 +55,7 @@ class Prompt(Generic[Input, Output]):
         self.backend = backend
 
     # START: Overloaded by the user prompts
-    def prompt(self, inp: Input) -> Request | str:
+    def prompt(self, inp: Input) -> Union[Request, str]:
         """
         Convert from the `Input` type of the function
         to a request that is sent to the backend.

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,6 @@ setup(
         "openai",
         "parsita==1.7.1",
         "trio",
-        "git+https://github.com/huggingface/hfapi/",
+        "hf-api @ git+https://github.com/huggingface/hfapi/",
     ],
 )


### PR DESCRIPTION
Thanks for the great repo. 

Added a couple of small fixes that I ran into during install and run:
- `git+https://github.com/huggingface/hfapi/` --> `hf-api @ git+https://github.com/huggingface/hfapi/` to stop setuptools from complaining
- replaced `|` with `Union`/`Optional` type hints for `py<=3.9'

Also added a barebones `Manifest` backend to support making API calls using `manifest.Manifest` clients from the [manifest](https://github.com/hazyresearch/manifest) library. That has nice support for a few different model providers (I'm biased). Didn't add `manifest-ml` to the requirements yet since it's only imported locally in the Backend, and I wasn't sure how you wanted to handle deps. Tested it on the math chain, also happy to add example / doc somewhere if you'd like.